### PR TITLE
add option to extend pre exec script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,19 +114,11 @@ Depending on your security requirements and secrets management, this process is 
 
 ```nix
 {
-  services.crowdsec = {
-    ExecStartPre = let
-      script = pkgs.writeScriptBin "register-bouncer" ''
-        #!${pkgs.runtimeShell}
-        set -eu
-        set -o pipefail
-
-        if ! cscli bouncers list | grep -q "my-bouncer"; then
-          cscli bouncers add "my-bouncer" --key "<api-key>"
-        fi
-      '';
-    in ["${script}/bin/register-bouncer"];
-  };
+  services.crowdsec.extraExecStartPre = ''
+    if ! cscli bouncers list | grep -q "my-bouncer"; then
+      cscli bouncers add "my-bouncer" --key "<api-key>"
+    fi
+  '';
 }
 
 ```

--- a/modules/crowdsec/default.nix
+++ b/modules/crowdsec/default.nix
@@ -127,6 +127,13 @@ in {
       type = format.type;
       default = {};
     };
+    extraExecStartPre = mkOption {
+      description = mkDoc ''
+        Script run pre starting the engine (e.g. to add bouncers or install collections)
+      '';
+      type = types.lines;
+      default = [];
+    };
   };
   config = let
     cscli = pkgs.writeScriptBin "cscli" ''
@@ -241,6 +248,7 @@ in {
                     fi
                   ''}
                 ''}
+                ${cfg.extraExecStartPre}
               '';
             in ["${script}/bin/crowdsec-setup"];
           };


### PR DESCRIPTION
This PR adds an simple option to extend the generated pre exec script. So the user can register bouncers and install collections without needing to know the internals of your chart (leading to better compatibility on further changes).